### PR TITLE
Remove date display from templates

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,7 @@ layout: default
 
   <header>
     <h1>{{ page.title }}</h1>
-    <p class="post-meta">{{ page.date | date: "%b %d, %Y" }} &middot; {{ page.author }} {% if page.categories %} &middot; {{ page.categories | join: ", " }}{% endif %} {% if page.reading_time %}&middot; {{ page.reading_time }} min read{% endif %}</p>
+    <p class="post-meta">{{ page.author }} {% if page.categories %} &middot; {{ page.categories | join: ", " }}{% endif %} {% if page.reading_time %}&middot; {{ page.reading_time }} min read{% endif %}</p>
   </header>
 
   {% if page.image %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -15,7 +15,7 @@ pagination:
   {% for post in paginator.posts %}
     <li>
       <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-      <span class="meta">— {{ post.date | date: "%b %d, %Y" }}</span>
+      <span class="meta">— {{ post.author }}</span>
     </li>
   {% endfor %}
   </ul>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ title: Home
     {% for post in site.posts limit:8 %}
       <li>
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        <span class="meta">— {{ post.date | date: "%b %d, %Y" }}</span>
+        <span class="meta">— {{ post.author }}</span>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Summary
- remove date display from post template and lists

## Testing
- not run (local Jekyll preview blocked by sandbox bind restrictions)